### PR TITLE
'带有接收者的函数字面值'示例sum函数参数错误

### DIFF
--- a/kotlin-tips-and-tricks.md
+++ b/kotlin-tips-and-tricks.md
@@ -251,7 +251,7 @@ A.(B) -> C
 
 ```java
 val sum = fun Int.(other: Int): Int = this + other
-println(sum(5 + 6))  // 11
+println(sum(5, 6))  // 11
 ```
 是不是还没有透彻，来一个完整的，很强大，可以尽情玩耍。
 


### PR DESCRIPTION
加号分隔的参数会先进行求和再传参, 实际应为逗号分隔的不同参数